### PR TITLE
Dod 1432

### DIFF
--- a/app/uk/gov/hmrc/ddcopsusermanagmentfrontendpocscala/connectors/UserConnector.scala
+++ b/app/uk/gov/hmrc/ddcopsusermanagmentfrontendpocscala/connectors/UserConnector.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.ddcopsusermanagmentfrontendpocscala.connectors
+
+import play.api.Configuration
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+import uk.gov.hmrc.ddcopsusermanagmentfrontendpocscala.domain.User
+import uk.gov.hmrc.http._
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class UserConnector @Inject() (httpClient: HttpClient, configuration: Configuration)(implicit
+  executionContext: ExecutionContext
+) {
+  val baseUrl: String =
+    configuration.get[String](
+      "connector.url"
+    )
+
+  implicit val readsUser: Reads[User] = (
+    (JsPath \ "name" \ "title").read[String] and
+      (JsPath \ "name" \ "first").read[String]
+  )(User.apply _)
+
+  def search(query: String)(implicit hc: HeaderCarrier): Future[List[User]] =
+    httpClient
+      .GET[HttpResponse](
+        url = url"$baseUrl?seed=$query"
+      )
+      .map(response => Json.parse(response.body)("results").as[List[User]])
+}

--- a/app/uk/gov/hmrc/ddcopsusermanagmentfrontendpocscala/connectors/UserConnector.scala
+++ b/app/uk/gov/hmrc/ddcopsusermanagmentfrontendpocscala/connectors/UserConnector.scala
@@ -39,6 +39,8 @@ class UserConnector @Inject() (httpClient: HttpClient, configuration: Configurat
   )(User.apply _)
 
   def search(query: String)(implicit hc: HeaderCarrier): Future[List[User]] =
+    // TODO get more results at a time
+    // TODO pagination offset?
     httpClient
       .GET[HttpResponse](
         url = url"$baseUrl?seed=$query"

--- a/app/uk/gov/hmrc/ddcopsusermanagmentfrontendpocscala/connectors/UserConnector.scala
+++ b/app/uk/gov/hmrc/ddcopsusermanagmentfrontendpocscala/connectors/UserConnector.scala
@@ -20,6 +20,7 @@ import play.api.Configuration
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 import uk.gov.hmrc.ddcopsusermanagmentfrontendpocscala.domain.User
+import uk.gov.hmrc.http.HttpReads.Implicits._
 import uk.gov.hmrc.http._
 
 import javax.inject.Inject
@@ -42,8 +43,6 @@ class UserConnector @Inject() (httpClient: HttpClient, configuration: Configurat
     // TODO get more results at a time
     // TODO pagination offset?
     httpClient
-      .GET[HttpResponse](
-        url = url"$baseUrl?seed=$query"
-      )
+      .GET[HttpResponse](url"$baseUrl?seed=$query")
       .map(response => Json.parse(response.body)("results").as[List[User]])
 }

--- a/app/uk/gov/hmrc/ddcopsusermanagmentfrontendpocscala/controllers/UserSearchController.scala
+++ b/app/uk/gov/hmrc/ddcopsusermanagmentfrontendpocscala/controllers/UserSearchController.scala
@@ -32,8 +32,8 @@ class UserSearchController @Inject() (
 )(implicit val executionContext: ExecutionContext)
     extends FrontendController(mcc) {
 
-  def userSearch: Action[AnyContent] = Action.async { implicit request =>
-    userConnector.search("john").map(users => Ok(userSearchPage(users)))
+  def userSearch(query: String): Action[AnyContent] = Action.async { implicit request =>
+    userConnector.search(query).map(users => Ok(userSearchPage(users)))
   }
 
 }

--- a/app/uk/gov/hmrc/ddcopsusermanagmentfrontendpocscala/controllers/UserSearchController.scala
+++ b/app/uk/gov/hmrc/ddcopsusermanagmentfrontendpocscala/controllers/UserSearchController.scala
@@ -19,17 +19,21 @@ package uk.gov.hmrc.ddcopsusermanagmentfrontendpocscala.controllers
 import uk.gov.hmrc.ddcopsusermanagmentfrontendpocscala.views.html.UserSearchPage
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.ddcopsusermanagmentfrontendpocscala.connectors.UserConnector
+
 import javax.inject.{Inject, Singleton}
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class UserSearchController @Inject()(
+class UserSearchController @Inject() (
   mcc: MessagesControllerComponents,
-  userSearchPage: UserSearchPage)
+  userSearchPage: UserSearchPage,
+  userConnector: UserConnector
+)(implicit val executionContext: ExecutionContext)
     extends FrontendController(mcc) {
 
-        val userSearch: Action[AnyContent] = Action.async { implicit request =>
-              Future.successful(Ok(userSearchPage()))
+  def userSearch: Action[AnyContent] = Action.async { implicit request =>
+    userConnector.search("john").map(users => Ok(userSearchPage(users)))
   }
 
 }

--- a/app/uk/gov/hmrc/ddcopsusermanagmentfrontendpocscala/controllers/UserSearchController.scala
+++ b/app/uk/gov/hmrc/ddcopsusermanagmentfrontendpocscala/controllers/UserSearchController.scala
@@ -16,13 +16,13 @@
 
 package uk.gov.hmrc.ddcopsusermanagmentfrontendpocscala.controllers
 
-import uk.gov.hmrc.ddcopsusermanagmentfrontendpocscala.views.html.UserSearchPage
-import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.ddcopsusermanagmentfrontendpocscala.connectors.UserConnector
+import uk.gov.hmrc.ddcopsusermanagmentfrontendpocscala.views.html.UserSearchPage
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
 import javax.inject.{Inject, Singleton}
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
 @Singleton
 class UserSearchController @Inject() (
@@ -37,5 +37,4 @@ class UserSearchController @Inject() (
   }
 
   // TODO have an autocomplete options endpoint?
-
 }

--- a/app/uk/gov/hmrc/ddcopsusermanagmentfrontendpocscala/controllers/UserSearchController.scala
+++ b/app/uk/gov/hmrc/ddcopsusermanagmentfrontendpocscala/controllers/UserSearchController.scala
@@ -33,7 +33,9 @@ class UserSearchController @Inject() (
     extends FrontendController(mcc) {
 
   def userSearch(query: String): Action[AnyContent] = Action.async { implicit request =>
-    userConnector.search(query).map(users => Ok(userSearchPage(users)))
+    userConnector.search(query).map(users => Ok(userSearchPage(users, query)))
   }
+
+  // TODO have an autocomplete options endpoint?
 
 }

--- a/app/uk/gov/hmrc/ddcopsusermanagmentfrontendpocscala/domain/User.scala
+++ b/app/uk/gov/hmrc/ddcopsusermanagmentfrontendpocscala/domain/User.scala
@@ -17,3 +17,5 @@
 package uk.gov.hmrc.ddcopsusermanagmentfrontendpocscala.domain
 
 case class User(title: String, firstName: String)
+
+// TODO define json writer for User

--- a/app/uk/gov/hmrc/ddcopsusermanagmentfrontendpocscala/domain/User.scala
+++ b/app/uk/gov/hmrc/ddcopsusermanagmentfrontendpocscala/domain/User.scala
@@ -1,4 +1,4 @@
-@*
+/*
  * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,20 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *@
+ */
 
-@import uk.gov.hmrc.ddcopsusermanagmentfrontendpocscala.domain.User
+package uk.gov.hmrc.ddcopsusermanagmentfrontendpocscala.domain
 
-@this(layout: Layout)
-
-@(users: List[User])(implicit request: Request[_], messages: Messages)
-
-@layout(pageTitle = Some("ddcops-user-managment-frontend-poc-scala")) {
-    <h1 class="govuk-heading-xl">ddcops-user-managment-frontend-poc-scala</h1>
-    <p class="govuk-body">@{messages("user.text")}</p>
-    <ul>
-    @for(user <- users) {
-      <li>@user.title @user.firstName</li>
-    }
-    </ul>
-}
+case class User(title: String, firstName: String)

--- a/app/uk/gov/hmrc/ddcopsusermanagmentfrontendpocscala/views/UserSearchPage.scala.html
+++ b/app/uk/gov/hmrc/ddcopsusermanagmentfrontendpocscala/views/UserSearchPage.scala.html
@@ -15,32 +15,33 @@
  *@
 
 @import uk.gov.hmrc.ddcopsusermanagmentfrontendpocscala.domain.User
-@import uk.gov.hmrc.govukfrontend.views.html.components._
+@import uk.gov.hmrc.ddcopsusermanagmentfrontendpocscala.views.html.Layout
+@import uk.gov.hmrc.govukfrontend.views.html.components.{Button, GovukButton, GovukInput, Hint, Input, Label, Text}
 
-@this(layout: Layout, govukInput : GovukInput, govukButton: GovukButton)
+@this(layout: Layout, govukInput: GovukInput, govukButton: GovukButton)
 
 @(users: List[User], query: String)(implicit request: Request[_], messages: Messages)
 
 @layout(pageTitle = Some("ddcops-user-managment-frontend-poc-scala")) {
-    <form method="get">
-      @govukInput(Input(
-        id = "search",
-        name = "query",
-        value = Some(query),
-        label = Label(
-          isPageHeading = true,
-          classes = "govuk-label--xl",
-          content = Text("Search users")
-        ),
-        hint = Some(Hint(content = Text("Enter all or part of a user detail to search users")))
-      ))
-      @govukButton(Button(inputType=Some("submit"), content= Text("Search")))
-      @* TODO move button to be to the right of search field *@
-    </form>
-    <ul>
-      @* TODO output as a table *@
+  <form method="get">
+    @govukInput(Input(
+      id = "search",
+      name = "query",
+      value = Some(query),
+      label = Label(
+        isPageHeading = true,
+        classes = "govuk-label--xl",
+        content = Text("Search users")
+      ),
+      hint = Some(Hint(content = Text("Enter all or part of a user detail to search users")))
+    ))
+    @govukButton(Button(inputType = Some("submit"), content = Text("Search")))
+    @* TODO move button to be to the right of search field *@
+  </form>
+  <ul>
+    @* TODO output as a table *@
     @for(user <- users) {
       <li>@user.title @user.firstName</li>
     }
-    </ul>
+  </ul>
 }

--- a/app/uk/gov/hmrc/ddcopsusermanagmentfrontendpocscala/views/UserSearchPage.scala.html
+++ b/app/uk/gov/hmrc/ddcopsusermanagmentfrontendpocscala/views/UserSearchPage.scala.html
@@ -15,15 +15,30 @@
  *@
 
 @import uk.gov.hmrc.ddcopsusermanagmentfrontendpocscala.domain.User
+@import uk.gov.hmrc.govukfrontend.views.html.components._
 
-@this(layout: Layout)
+@this(layout: Layout, govukInput : GovukInput, govukButton: GovukButton)
 
-@(users: List[User])(implicit request: Request[_], messages: Messages)
+@(users: List[User], query: String)(implicit request: Request[_], messages: Messages)
 
 @layout(pageTitle = Some("ddcops-user-managment-frontend-poc-scala")) {
-    <h1 class="govuk-heading-xl">ddcops-user-managment-frontend-poc-scala</h1>
-    <p class="govuk-body">@{messages("user.text")}</p>
+    <form method="get">
+      @govukInput(Input(
+        id = "search",
+        name = "query",
+        value = Some(query),
+        label = Label(
+          isPageHeading = true,
+          classes = "govuk-label--xl",
+          content = Text("Search users")
+        ),
+        hint = Some(Hint(content = Text("Enter all or part of a user detail to search users")))
+      ))
+      @govukButton(Button(inputType=Some("submit"), content= Text("Search")))
+      @* TODO move button to be to the right of search field *@
+    </form>
     <ul>
+      @* TODO output as a table *@
     @for(user <- users) {
       <li>@user.title @user.firstName</li>
     }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -2,5 +2,5 @@
 
 ->         /hmrc-frontend           hmrcfrontend.Routes
 GET        /                        uk.gov.hmrc.ddcopsusermanagmentfrontendpocscala.controllers.HelloWorldController.helloWorld
-GET        /search-user             uk.gov.hmrc.ddcopsusermanagmentfrontendpocscala.controllers.UserSearchController.userSearch
+GET        /search-user             uk.gov.hmrc.ddcopsusermanagmentfrontendpocscala.controllers.UserSearchController.userSearch(query: String ?= "")
 GET        /assets/*file            controllers.Assets.versioned(path = "/public", file: Asset)

--- a/test/uk/gov/hmrc/ddcopsusermanagmentfrontendpocscala/UserConnectorSpec.scala
+++ b/test/uk/gov/hmrc/ddcopsusermanagmentfrontendpocscala/UserConnectorSpec.scala
@@ -37,36 +37,10 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import play.api.Configuration
-import play.api.libs.functional.syntax._
-import play.api.libs.json._
-import uk.gov.hmrc.http.HttpReads.Implicits._
+import uk.gov.hmrc.ddcopsusermanagmentfrontendpocscala.connectors.UserConnector
+import uk.gov.hmrc.ddcopsusermanagmentfrontendpocscala.domain.User
 import uk.gov.hmrc.http._
 import uk.gov.hmrc.http.test.{HttpClientSupport, WireMockSupport}
-
-import scala.concurrent.{ExecutionContext, Future}
-
-case class User(title: String, firstName: String)
-
-class UserConnector(httpClient: HttpClient, configuration: Configuration)(implicit
-  executionContext: ExecutionContext
-) {
-  val baseUrl: String =
-    configuration.get[String](
-      "connector.url"
-    )
-
-  implicit val readsUser: Reads[User] = (
-    (JsPath \ "name" \ "title").read[String] and
-      (JsPath \ "name" \ "first").read[String]
-  )(User.apply _)
-
-  def search(query: String)(implicit hc: HeaderCarrier): Future[List[User]] =
-    httpClient
-      .GET[HttpResponse](
-            url = url"$baseUrl?seed=$query"
-      )
-      .map(response => Json.parse(response.body)("results").as[List[User]])
-}
 
 class UserConnectorSpec
     extends AnyWordSpec


### PR DESCRIPTION
- moved the connector we created for searching for users out of the test suite and into it's proper location
- inject the connector into our search controller
- pass the results of searching with the connector with a fixed string for users to the page template
- update page template to display the users in a list
- update controller so that we accept a query param "?query=something" and use that as the seed for the search
- update the page template with a search form that submits to the same url and changes the ?query url parameter
- pass the ?query url parameter from the controller to the template and use it as the value of the search field so that the value of the form field persists in the form